### PR TITLE
Add TimeCreated event filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-target = "x86_64-pc-windows-gnu"
 
 [dependencies]
 bitflags = "2"
-chrono = "0.4.39"
+chrono = "^0.4.38"
 lazy_static = "1.2.0"
 serde = { version = "1.0.85", optional = true, features = [ "derive" ] }
 serde_derive = { version = "1.0.85", optional = true, default-features = false }
@@ -33,4 +33,4 @@ xml = ["serde", "quick-xml"]
 subscriber = []
 
 [dev-dependencies]
-chrono = "0.4.39"
+chrono = "^0.4.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ default-target = "x86_64-pc-windows-gnu"
 
 [dependencies]
 bitflags = "2"
+chrono = "0.4.39"
 lazy_static = "1.2.0"
 serde = { version = "1.0.85", optional = true, features = [ "derive" ] }
 serde_derive = { version = "1.0.85", optional = true, default-features = false }
@@ -30,3 +31,6 @@ features = ["errhandlingapi", "minwindef", "winnt", "winevt", "libloaderapi", "s
 default = ["xml"]
 xml = ["serde", "quick-xml"]
 subscriber = []
+
+[dev-dependencies]
+chrono = "0.4.39"

--- a/src/api.rs
+++ b/src/api.rs
@@ -369,7 +369,7 @@ mod tests {
         let query = r#"<QueryList>
 <Query Id="0">
 <Select Path="Security">
-*[System[((Level = 0) or (Level >= 4))]]
+*[System[((Level = 0) or (Level &gt;= 4))]]
 and
 *[EventData[((Data[@Name = 'TargetUserName']) and (Data = 'SYSTEM'))]]
 </Select>

--- a/src/query_list/event_filter/time_created.rs
+++ b/src/query_list/event_filter/time_created.rs
@@ -1,0 +1,26 @@
+use chrono::{DateTime, SecondsFormat, Utc};
+use std::fmt;
+use crate::query_list::Comparison;
+
+#[derive(Clone)]
+pub struct TimeCreated {
+    time: DateTime<Utc>,
+    comparison: Comparison,
+}
+
+impl TimeCreated {
+    pub fn new(time: DateTime<Utc>, comparison: Comparison) -> TimeCreated {
+        TimeCreated { time, comparison }
+    }
+}
+
+impl fmt::Display for TimeCreated {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let iso_time = self.time.to_rfc3339_opts(SecondsFormat::Millis, true);
+        write!(
+            f,
+            "TimeCreated[@SystemTime {} '{}']",
+            self.comparison, iso_time
+        )
+    }
+}

--- a/src/query_list/mod.rs
+++ b/src/query_list/mod.rs
@@ -22,10 +22,10 @@ impl std::fmt::Display for Comparison {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
             Comparison::Equal => write!(f, "="),
-            Comparison::GreaterThan => write!(f, ">"),
-            Comparison::LessThan => write!(f, "<"),
-            Comparison::GreaterThanOrEqual => write!(f, ">="),
-            Comparison::LessThanOrEqual => write!(f, "<="),
+            Comparison::GreaterThan => write!(f, "&gt;"),
+            Comparison::LessThan => write!(f, "&lt;"),
+            Comparison::GreaterThanOrEqual => write!(f, "&gt;="),
+            Comparison::LessThanOrEqual => write!(f, "&lt;="),
         }
     }
 }
@@ -162,7 +162,7 @@ mod tests {
             r#"<QueryList>
 <Query Id="0">
 <Select Path="Application">
-*[System[((Level = 1) or (Level >= 4))]]
+*[System[((Level = 1) or (Level &gt;= 4))]]
 </Select>
 </Query>
 </QueryList>"#
@@ -198,7 +198,7 @@ mod tests {
             r#"<QueryList>
 <Query Id="0">
 <Select Path="Security">
-*[System[((Level = 0) or (Level >= 4))]]
+*[System[((Level = 0) or (Level &gt;= 4))]]
 and
 *[EventData[((Data[@Name = 'TargetUserName'] and Data = 'SYSTEM'))]]
 </Select>


### PR DESCRIPTION
Also fixed escaping of `>` and `<` characters in the query XML, otherwise we get error 15008: "The specified XML text was not well-formed. See Extended Error for more details."